### PR TITLE
feat: central platform bundle + deploy-platform task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -192,6 +192,176 @@ tasks:
       CILIUM_CRDS_KUSTOMIZE: https://github.com/stuttgart-things/helm/infra/crds/cilium
       CILIUM_HELMFILE_REF: "git::https://github.com/stuttgart-things/helm.git@infra/cilium.yaml.gotmpl"
 
+  deploy-platform:
+    desc: Deploy the platform bundle (cilium/openebs/tekton/crossplane) via the central helmfile
+    vars:
+      HELM_DAGGER_MODULE: github.com/stuttgart-things/dagger/helm@v0.57.0
+      HELM_GIT_REPO: git::https://github.com/stuttgart-things/helm.git
+      BUNDLE_DIR: bundles
+      BUNDLE_FILE: platform.yaml.gotmpl
+      KUBECONFIG_PATH: ~/.kube
+      ALL_KUBECONFIGS:
+        sh: ls {{ .KUBECONFIG_PATH }} | grep -v "^cache$" | xargs -n1 printf '"%s" '
+    cmds:
+      - |
+        set -e
+
+        # SELECT KUBECONFIG
+        SELECTED_KUBECONFIG=$(gum choose {{ .ALL_KUBECONFIGS }})
+        export KUBECONFIG={{ .KUBECONFIG_PATH }}/${SELECTED_KUBECONFIG//\"/}
+        echo "SWITCHING TO ${KUBECONFIG}"
+        kubectl get nodes
+
+        # SELECT COMPONENTS (pre-selected = bundle defaults)
+        SELECTED=$(gum choose --no-limit --header "Components to deploy" \
+          --selected="openebs,tekton,crossplane" \
+          "openebs" "tekton" "crossplane" "cilium")
+        [ -z "$SELECTED" ] && { echo "Nothing selected."; exit 0; }
+        on() { echo "$SELECTED" | grep -qx "$1" && echo true || echo false; }
+        STATE="openebsEnabled=$(on openebs),tektonEnabled=$(on tekton),crossplaneEnabled=$(on crossplane),ciliumEnabled=$(on cilium)"
+        echo "Components: ${SELECTED//$'\n'/ }  ->  ${STATE}"
+
+        gum confirm "Deploy platform bundle to ${KUBECONFIG}?" || exit 0
+
+        # APPLY THE BUNDLE — composes the helm-repo helmfiles (remote) into one apply.
+        dagger call -m {{ .HELM_DAGGER_MODULE }} \
+          helmfile-operation \
+          --operation apply \
+          --src {{ .BUNDLE_DIR }} \
+          --helmfile-ref {{ .BUNDLE_FILE }} \
+          --state-values "${STATE}" \
+          --kube-config file://${KUBECONFIG} \
+          --progress plain -vv
+
+        # FINALIZE CROSSPLANE — the bundle intentionally omits provider-configs
+        # (their CRDs only exist once the providers/config are Healthy). Apply
+        # them here, after waiting, if crossplane was part of this run.
+        if echo "$SELECTED" | grep -qx crossplane; then
+          echo "▶ Finalizing Crossplane provider-configs..."
+          kubectl -n crossplane-system rollout status deploy/crossplane --timeout=180s
+          kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+          kubectl wait configuration.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+          echo "Waiting for kubernetes.m.crossplane.io CRD (transitive provider-kubernetes)..."
+          for i in $(seq 1 60); do
+            kubectl get crd clusterproviderconfigs.kubernetes.m.crossplane.io >/dev/null 2>&1 && break
+            sleep 5
+          done
+          kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+          kubectl wait function.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+          dagger call -m {{ .HELM_DAGGER_MODULE }} \
+            helmfile-operation \
+            --operation apply \
+            --helmfile-ref "{{ .HELM_GIT_REPO }}@cicd/crossplane-provider-configs.yaml.gotmpl" \
+            --kube-config file://${KUBECONFIG} \
+            --progress plain -vv
+        fi
+
+        echo "✅ PLATFORM DEPLOYED"
+        kubectl get nodes
+
+  deploy-crossplane:
+    desc: Deploy Crossplane (core, providers, functions/configs, provider-configs) via dagger helmfile-operation
+    vars:
+      HELM_DAGGER_MODULE: github.com/stuttgart-things/dagger/helm@v0.57.0
+      HELM_GIT_REPO: git::https://github.com/stuttgart-things/helm.git
+      KUBECONFIG_PATH: ~/.kube
+      ALL_KUBECONFIGS:
+        sh: ls {{ .KUBECONFIG_PATH }} | grep -v "^cache$" | xargs -n1 printf '"%s" '
+    cmds:
+      - |
+        set -e
+
+        # SELECT KUBECONFIG
+        SELECTED_KUBECONFIG=$(gum choose {{ .ALL_KUBECONFIGS }})
+        export KUBECONFIG={{ .KUBECONFIG_PATH }}/${SELECTED_KUBECONFIG//\"/}
+        echo "SWITCHING TO ${KUBECONFIG}"
+        kubectl get nodes
+
+        gum confirm "Deploy Crossplane to ${KUBECONFIG}?" || exit 0
+
+        apply() {
+          echo "▶ APPLYING: $1"
+          dagger call -m {{ .HELM_DAGGER_MODULE }} \
+            helmfile-operation \
+            --operation apply \
+            --helmfile-ref "{{ .HELM_GIT_REPO }}@$1" \
+            --kube-config file://${KUBECONFIG} \
+            --progress plain -vv
+        }
+
+        # 1) CORE — installs Crossplane + package CRDs
+        apply cicd/crossplane.yaml.gotmpl
+        kubectl -n crossplane-system rollout status deploy/crossplane --timeout=180s
+
+        # 2) PROVIDERS — Provider CRs + RBAC only (ProviderConfigs are a
+        #    separate helmfile, applied in step 4 once the CRDs exist).
+        apply cicd/crossplane-providers.yaml.gotmpl
+        kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # 3) FUNCTIONS + CONFIGURATIONS — Configurations pull provider-kubernetes
+        #    transitively via dependsOn, which creates the kubernetes.m.crossplane.io CRD.
+        apply cicd/crossplane-config.yaml.gotmpl
+        kubectl wait configuration.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # wait for the transitive provider-kubernetes CRD before applying provider-configs
+        echo "Waiting for kubernetes.m.crossplane.io CRD (transitive provider-kubernetes)..."
+        for i in $(seq 1 60); do
+          kubectl get crd clusterproviderconfigs.kubernetes.m.crossplane.io >/dev/null 2>&1 && break
+          sleep 5
+        done
+        kubectl wait provider.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+        kubectl wait function.pkg.crossplane.io --all --for=condition=Healthy --timeout=300s
+
+        # 4) PROVIDER-CONFIGS — separate helmfile; all ProviderConfig CRDs now exist
+        apply cicd/crossplane-provider-configs.yaml.gotmpl
+
+        echo "✅ CROSSPLANE DEPLOYED"
+        kubectl get provider.pkg.crossplane.io,function.pkg.crossplane.io,configuration.pkg.crossplane.io
+
+  deploy-tekton:
+    desc: Deploy Tekton (operator + pipeline component) via dagger helmfile-operation
+    vars:
+      HELM_DAGGER_MODULE: github.com/stuttgart-things/dagger/helm@v0.57.0
+      HELM_GIT_REPO: git::https://github.com/stuttgart-things/helm.git
+      KUBECONFIG_PATH: ~/.kube
+      ALL_KUBECONFIGS:
+        sh: ls {{ .KUBECONFIG_PATH }} | grep -v "^cache$" | xargs -n1 printf '"%s" '
+    cmds:
+      - |
+        set -e
+
+        # SELECT KUBECONFIG
+        SELECTED_KUBECONFIG=$(gum choose {{ .ALL_KUBECONFIGS }})
+        export KUBECONFIG={{ .KUBECONFIG_PATH }}/${SELECTED_KUBECONFIG//\"/}
+        echo "SWITCHING TO ${KUBECONFIG}"
+        kubectl get nodes
+
+        gum confirm "Deploy Tekton to ${KUBECONFIG}?" || exit 0
+
+        # APPLY — installs the Tekton Operator; with autoInstallComponents=false
+        # + enableTektonPipeline=true the chart renders a TektonPipeline CR
+        # (Pipelines only, no Dashboard/Triggers/Chains).
+        echo "▶ APPLYING: cicd/tekton.yaml.gotmpl"
+        dagger call -m {{ .HELM_DAGGER_MODULE }} \
+          helmfile-operation \
+          --operation apply \
+          --helmfile-ref "{{ .HELM_GIT_REPO }}@cicd/tekton.yaml.gotmpl" \
+          --kube-config file://${KUBECONFIG} \
+          --progress plain -vv
+
+        # WAIT for operator + the pipeline component to be ready
+        kubectl -n tekton-operator rollout status deploy/tekton-operator --timeout=180s
+        echo "Waiting for TektonPipeline CR to be created by the operator..."
+        for i in $(seq 1 60); do
+          kubectl get tektonpipeline pipeline >/dev/null 2>&1 && break
+          sleep 5
+        done
+        kubectl wait tektonpipeline --all --for=condition=Ready --timeout=300s
+
+        echo "✅ TEKTON DEPLOYED"
+        kubectl get tektonpipeline
+        kubectl -n tekton-pipelines get pods
+
   do:
     desc: Select a task to run
     cmds:

--- a/bundles/platform.yaml.gotmpl
+++ b/bundles/platform.yaml.gotmpl
@@ -1,0 +1,52 @@
+---
+# Central platform bundle — composes the stuttgart-things/helm helmfiles into
+# one callable state. Toggle components via *Enabled state values; pin the
+# source ref with `ref` (default: main).
+#
+#   helmfile -f bundles/platform.yaml.gotmpl apply
+#   # selective:
+#   helmfile -f bundles/platform.yaml.gotmpl --state-values-set tektonEnabled=false apply
+#
+# Sub-helmfiles are fetched from the helm repo (git). Crossplane's
+# provider-configs are intentionally NOT part of this bundle: they reference
+# ProviderConfig CRDs that only register once the providers are Healthy, so a
+# flat apply can't satisfy them. Apply cicd/crossplane-provider-configs.yaml.gotmpl
+# afterwards (the deploy-platform / deploy-crossplane task does this with waits).
+environments:
+  default:
+    values:
+      - ciliumEnabled: {{ dig "ciliumEnabled" false .Values }}
+      - openebsEnabled: {{ dig "openebsEnabled" true .Values }}
+      - crossplaneEnabled: {{ dig "crossplaneEnabled" true .Values }}
+      - tektonEnabled: {{ dig "tektonEnabled" true .Values }}
+      # source ref of the stuttgart-things/helm repo
+      - ref: {{ dig "ref" "main" .Values }}
+      # cilium state values (only consumed when ciliumEnabled)
+      - config: {{ dig "config" "kind" .Values }}
+      - clusterName: {{ dig "clusterName" "kind" .Values }}
+      - configureLB: {{ dig "configureLB" false .Values }}
+---
+helmfiles:
+{{- if .Values.ciliumEnabled }}
+  # CNI first — nodes stay NotReady until a CNI is installed.
+  - path: git::https://github.com/stuttgart-things/helm.git@infra/cilium.yaml.gotmpl?ref={{ .Values.ref }}
+    values:
+      - config: {{ .Values.config }}
+      - clusterName: {{ .Values.clusterName }}
+      - configureLB: {{ .Values.configureLB }}
+{{- end }}
+{{- if .Values.openebsEnabled }}
+  # Storage (openebs-hostpath / localpv).
+  - path: git::https://github.com/stuttgart-things/helm.git@infra/openebs.yaml.gotmpl?ref={{ .Values.ref }}
+{{- end }}
+{{- if .Values.tektonEnabled }}
+  # Tekton operator + pipeline component (Pipelines only).
+  - path: git::https://github.com/stuttgart-things/helm.git@cicd/tekton.yaml.gotmpl?ref={{ .Values.ref }}
+{{- end }}
+{{- if .Values.crossplaneEnabled }}
+  # Crossplane core + providers (+RBAC) + functions/configurations.
+  # provider-configs are applied separately (see header note).
+  - path: git::https://github.com/stuttgart-things/helm.git@cicd/crossplane.yaml.gotmpl?ref={{ .Values.ref }}
+  - path: git::https://github.com/stuttgart-things/helm.git@cicd/crossplane-config.yaml.gotmpl?ref={{ .Values.ref }}
+  - path: git::https://github.com/stuttgart-things/helm.git@cicd/crossplane-providers.yaml.gotmpl?ref={{ .Values.ref }}
+{{- end }}


### PR DESCRIPTION
## Summary

Adds a **central platform bundle** you can call once to deploy the stuttgart-things platform onto a cluster (typically kind), plus a `deploy-platform` task.

### `bundles/platform.yaml.gotmpl`
A helmfile that composes the individual `stuttgart-things/helm` helmfiles via helmfile `helmfiles:` (remote git refs), toggled per component:

| Toggle | Default | Sub-helmfile |
|---|---|---|
| `ciliumEnabled` | false | `infra/cilium` |
| `openebsEnabled` | true | `infra/openebs` |
| `tektonEnabled` | true | `cicd/tekton` |
| `crossplaneEnabled` | true | `cicd/crossplane` + `-config` + `-providers` |

- Source ref pinnable via `ref` (default `main`).
- Crossplane **provider-configs are intentionally excluded** — their ProviderConfig CRDs only register once the providers (and the transitive `provider-kubernetes`) are Healthy, so a flat `helmfile apply` can't satisfy them. They are applied afterwards with health waits (see the task). This relies on the provider-configs having been split into their own helmfile in the helm repo (stuttgart-things/helm#150).

### Taskfile
- **`deploy-platform`** (new): pick components via `gum`, apply the bundle via the dagger helm module, then finalize the Crossplane provider-configs (with health waits) if crossplane was selected.
- **`deploy-crossplane`**: updated to the split — the providers step no longer expects a failure; step 4 applies `cicd/crossplane-provider-configs.yaml.gotmpl`.
- **`deploy-tekton`**: deploy Tekton via the helm helmfile.

### Testing
`helmfile -f bundles/platform.yaml.gotmpl build` composes cleanly — remote sub-helmfiles are fetched from the helm repo and their relative value files resolve (default toggles and `ciliumEnabled=true` both build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)