### PR TITLE
feat(taskfile): safer destroy-kind-cluster (orphan warning + kubeconfig prune)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -29,7 +29,9 @@ tasks:
         - keycloak
 
   destroy-kind-cluster:
-    desc: Destroy a KinD cluster
+    desc: Destroy a KinD cluster (warns on orphaned Crossplane-managed infra, prunes its kubeconfig)
+    vars:
+      KUBECONFIG_PATH: ~/.kube
     cmds:
       - |
         CLUSTERS=$(kind get clusters)
@@ -40,10 +42,32 @@ tasks:
 
         CLUSTER_NAME=$(echo "$CLUSTERS" | gum choose)
         echo "You chose: $CLUSTER_NAME"
+        # create-kind-cluster writes the kubeconfig to KUBECONFIG_PATH/<name>.
+        KUBECONFIG_FILE={{ .KUBECONFIG_PATH }}/"$CLUSTER_NAME"
+
+        # ORPHAN CHECK — `kind delete` removes the cluster wholesale, so any Crossplane
+        # managed resources (VMs in vSphere/Proxmox, …) are ORPHANED, not deleted by their
+        # providers. Warn (and offer to abort) so external infra can be torn down first.
+        if [ -f "$KUBECONFIG_FILE" ]; then
+          MANAGED=$(KUBECONFIG="$KUBECONFIG_FILE" kubectl get managed 2>/dev/null | tail -n +2 || true)
+          if [ -n "$MANAGED" ]; then
+            echo "⚠️  This cluster still manages external infrastructure — it would be ORPHANED:"
+            echo "$MANAGED" | sed 's/^/    /'
+            echo "  Tear it down first, e.g.:  kubectl delete nativevspherevm <name> -n <ns>"
+            echo "  and let the provider remove the real VMs, THEN destroy the cluster."
+            gum confirm "Destroy anyway and orphan the above?" || { echo "Aborted."; exit 0; }
+          fi
+        fi
 
         if gum confirm "Do you really want to delete cluster $CLUSTER_NAME?"; then
           kind delete cluster --name "$CLUSTER_NAME"
           echo "Cluster $CLUSTER_NAME deleted."
+          # PRUNE kubeconfig — `kind delete` leaves KUBECONFIG_PATH/<name> behind, which
+          # then lingers as a stale entry in the bootstrap / deploy-* kubeconfig pickers.
+          if [ -f "$KUBECONFIG_FILE" ]; then
+            rm -f "$KUBECONFIG_FILE"
+            echo "Removed stale kubeconfig $KUBECONFIG_FILE"
+          fi
         else
           echo "Aborted."
         fi


### PR DESCRIPTION
Two safety improvements to `destroy-kind-cluster`:

1. **Orphan warning** — `kind delete` removes the cluster wholesale, so any Crossplane `managed` resources (real VMs in vSphere/Proxmox, …) are orphaned rather than deleted by their providers. The task now checks `kubectl get managed` first and, if any exist, lists them and requires an explicit confirm to orphan — pointing you to tear them down gracefully first (`kubectl delete nativevspherevm <name> -n <ns>`).
2. **Kubeconfig prune** — `kind delete` leaves `~/.kube/<name>` behind, which then lingers as a stale entry in the `bootstrap` / `deploy-*` kubeconfig pickers. The task now removes it after deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)