### PR TITLE
docs(readme): document the three-tier cluster bootstrap tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,43 @@ Composable infrastructure for fast-moving teams
 | 🚚 [KARGO](./kargo/README.md)        | Progressive delivery and GitOps for Kubernetes workloads |
 | 🛡️ [KEYCLOAK](./keycloak/README.md)  | Identity and access management for modern applications |
 
+## Cluster Bootstrap
+
+Build a cluster from scratch with the interactive [`Taskfile`](./Taskfile.yaml) (gum-driven,
+step-by-step confirmations). It's structured in three tiers so it scales to multiple cluster types:
+
+| Tier | Task | What |
+|------|------|------|
+| **substrate** | `create-kind-cluster` | kind cluster + cilium CNI |
+| **foundation** | `deploy-foundation` | cert-manager → sops-secrets-operator (+ age key) → openebs |
+| **profile** | `profile-machinery` | tekton → crossplane → Configuration packages → capabilities |
+
+```bash
+# one guided run: substrate → foundation → choose profile(s)
+task bootstrap
+
+# …or run any tier / building block on its own
+task create-kind-cluster
+task deploy-foundation
+task profile-machinery
+```
+
+The **machinery** profile makes the cluster a VM builder: apply a `NativeVsphereVM` XR and
+Crossplane provisions a VM in vSphere (labul/labda), optionally running an Ansible base-OS
+playbook via Tekton. `deploy-capabilities` can enable multiple environments at once
+(labul **and** labda on one cluster). Add a new cluster type as a `profile-<name>` task and
+list it in `bootstrap` — substrate + foundation stay unchanged.
+
+**Building-block tasks** (interactive, reusable standalone): `deploy-cert-manager`,
+`deploy-sops`, `deploy-openebs`, `deploy-tekton`, `deploy-crossplane`, `deploy-configurations`,
+`deploy-capabilities`. List everything with `task` (or `task do`).
+
+> The `sops` credentials backend needs the project age private key in your environment —
+> `export SOPS_AGE_KEY=…` before `deploy-sops` / `deploy-capabilities`.
+
+Tear down with `task destroy-kind-cluster` — it warns on orphaned Crossplane-managed VMs and
+prunes the leftover kubeconfig.
+
 ## AUTHORS
 
 ```yaml


### PR DESCRIPTION
Adds a **Cluster Bootstrap** section to the top-level README documenting the new Taskfile workflow:

- Three-tier structure (substrate → foundation → profile) as a table
- `task bootstrap` quick-start + running tiers/building blocks standalone
- What the **machinery** profile does (VM builder; multi-env labul+labda; Ansible base-OS via Tekton) and how to add future `profile-<name>` types
- Building-block task list, `SOPS_AGE_KEY` prerequisite, and `destroy-kind-cluster` teardown

Documents the tasks landed in #79 and #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)