### PR TITLE
chore(taskfile): vspherevm chart 0.10.0 (labul datastore aligned)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -533,7 +533,7 @@ tasks:
       # age-encrypted creds blobs for the sops backend (variant B, supplied at deploy).
       SECRETS_DIR: '{{ .SECRETS_DIR | default "~/projects/stuttgart-things/secrets" }}'
       # Pinned chart versions (bump on release).
-      VSPHEREVM_VER: "0.9.0"
+      VSPHEREVM_VER: "0.10.0"
       ANSIBLE_VER: "0.3.0"
       PROXMOXVM_VER: "0.3.0"
       ALL_KUBECONFIGS:


### PR DESCRIPTION
deploy-capabilities pulls vspherevm chart 0.10.0 (labul datastore aligned to UL-V5010-01-LUN1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)