### PR TITLE
Enhance git:commit & git:pr tasks with interactive staging & convention-compliant messages

### DIFF
--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -822,7 +822,7 @@ task --taskfile taskfiles/git.yaml commit
 3. **Select Files:** Pick exactly which changed files to stage (space to toggle, enter to confirm)
 4. **Compose Message:**
    - **Type:** Conventional Commits type via `gum choose` (`feat`, `fix`, `docs`, … or `none`)
-   - **Ticket:** Auto-parsed from the branch (e.g. `feature/cloud-42_…` → `CLOUD-42`), validated as `PROJECT-NUMBER`, forced UPPERCASE
+   - **Ticket (optional):** Auto-parsed from the branch (e.g. `feature/cloud-42_…` → `CLOUD-42`); when set it is validated as `PROJECT-NUMBER` and forced UPPERCASE. Leave empty to omit the ticket reference entirely.
    - **Summary:** Must start with a capital letter; full subject line is capped at **72 characters**
    - **Body (optional):** Multi-line via `gum write`, separated from the subject by a blank line
 5. **Confirm:** Review the assembled message, then confirm or abort (staged files are kept on abort)
@@ -848,9 +848,10 @@ task --taskfile taskfiles/git.yaml commit
 
 </details>
 
-<details><summary><b>🔀 pr - Create and Merge Pull Request</b></summary>
+<details><summary><b>🔀 pr - Create a Pull / Merge Request into main</b></summary>
 
-Automate pull request creation, checks, and merge into main.
+Create a pull request (GitHub) or merge request (GitLab) into main. The forge is
+auto-detected from the `origin` remote, so the same task works on both platforms.
 
 ```bash
 task --taskfile taskfiles/git.yaml pr
@@ -858,30 +859,36 @@ task --taskfile taskfiles/git.yaml pr
 
 **Features:**
 - Commits changes first (runs `commit` task)
-- Creates PR via GitHub CLI
-- Auto-merge with rebase strategy
-- Auto-delete source branch after merge
-- Switches back to main and pulls latest
+- **Platform-agnostic:** GitHub via `gh`, GitLab via `glab` — auto-detected from the remote URL
+- **Draft = private/WIP** per the review flow; non-draft is public and queued for auto-merge
+- **Squash** merge strategy (per the "ENFORCE Squash" policy)
+- Auto-delete / remove source branch after merge
+- Switches back to main and pulls latest (only for non-draft requests)
 
 **Workflow:**
-1. **Commit:** Runs commit task
-2. **Create PR:** `gh pr create -t "<branch>" -b "<branch> branch into main"`
-3. **Wait:** 2s delay for PR creation
-4. **Auto-merge:** Enables auto-merge with rebase
-5. **Cleanup:** Deletes branch after merge
-6. **Switch to main:** Checks out main and pulls latest
+1. **Commit:** Runs the `commit` task
+2. **Detect platform:** Reads `git remote get-url origin` (`github` / `gitlab`), or asks if ambiguous
+3. **Title & description:** Prompted via `gum input` / `gum write`
+4. **Draft?:** `gum confirm` — Draft keeps the request private and skips auto-merge
+5. **Create request:**
+   - GitHub: `gh pr create --base main --head <branch> …`
+   - GitLab: `glab mr create --target-branch main --source-branch <branch> … --squash-before-merge`
+6. **Auto-merge (non-draft only):**
+   - GitHub: `gh pr merge --auto --squash --delete-branch`
+   - GitLab: `glab mr merge --squash --remove-source-branch --when-pipeline-succeeds`
+7. **Switch to main:** Only when the request was queued for merge (non-draft)
 
 **Requirements:**
-- GitHub CLI (`gh`) installed and authenticated
-- Branch protection rules configured (optional)
-- CI checks configured for auto-merge
+- GitHub CLI (`gh`) **or** GitLab CLI (`glab`) installed and authenticated
+- Branch protection / CI checks configured for auto-merge
 
 **Example:**
 ```bash
-git checkout -b feat/new-taskfile
+git checkout -b feature/cloud-42_new_taskfile
 # ... make changes ...
 task --taskfile taskfiles/git.yaml pr
-# Creates PR, waits for checks, auto-merges, switches to main
+# Detects the forge, prompts for title/description, asks Draft?,
+# then creates the PR/MR and (if non-draft) queues a squash auto-merge.
 ```
 
 </details>

--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -802,7 +802,7 @@ Interactive taskfile for Git workflow automation with conventional commits and p
 
 <details><summary><b>💾 commit - Commit & Push Changes</b></summary>
 
-Interactive commit workflow with conventional commit support and change review.
+Interactive commit workflow with per-file staging and a convention-compliant commit message.
 
 ```bash
 task --taskfile taskfiles/git.yaml commit
@@ -811,38 +811,39 @@ task --taskfile taskfiles/git.yaml commit
 **Features:**
 - Pre-commit hook execution
 - Git status review before commit
-- Conventional commit message templates
-- Custom commit messages with file context
-- Automatic push to origin
+- **Interactive per-file staging** (`gum choose --no-limit`) — only the files you pick are committed, never a blanket `git add *`
+- **Convention-compliant subject:** `[<type>: ]<TICKET-REF>: <Summary>`, with validation
+- Optional extended body (blank-line separated)
+- Rebase-based sync + push (keeps history linear)
 
 **Workflow:**
 1. **Pre-commit Checks:** Runs `pre-commit` hooks (formatting, linting, etc.)
-2. **Set Upstream:** Links branch to remote
-3. **Pull Latest:** Syncs with remote branch
-4. **Review Changes:** Shows `git status`
-5. **Confirm Commit:** Review changes, confirm or cancel
-6. **Commit Message:**
-   - `CUSTOM MESSAGE` - Enter your own message (shows changed files)
-   - `feat: <branch-name>` - New feature
-   - `fix: <branch-name>` - Bug fix
-   - `BREAKING CHANGE: <branch-name>` - Breaking change
-7. **Push:** Automatic push to origin
+2. **Review Changes:** Shows `git status --short`; exits early if the tree is clean
+3. **Select Files:** Pick exactly which changed files to stage (space to toggle, enter to confirm)
+4. **Compose Message:**
+   - **Type:** Conventional Commits type via `gum choose` (`feat`, `fix`, `docs`, … or `none`)
+   - **Ticket:** Auto-parsed from the branch (e.g. `feature/cloud-42_…` → `CLOUD-42`), validated as `PROJECT-NUMBER`, forced UPPERCASE
+   - **Summary:** Must start with a capital letter; full subject line is capped at **72 characters**
+   - **Body (optional):** Multi-line via `gum write`, separated from the subject by a blank line
+5. **Confirm:** Review the assembled message, then confirm or abort (staged files are kept on abort)
+6. **Sync & Push:** `git pull --rebase --autostash` (if an upstream exists), then `git push -u origin <branch>`
 
-**Examples:**
+Resulting subject examples (per the Git Development/Review Flow naming convention):
+
+```text
+CLOUD-42: Add missing LICENSE information to pyproject.toml
+fix: CLOUD-42: Correct YAML formatting in flux module
+```
+
+**Example:**
 
 ```bash
-# Feature branch workflow
-git checkout -b feat/add-flux-secrets
+git checkout -b feature/cloud-42_add_flux_secrets
 # ... make changes ...
 task --taskfile taskfiles/git.yaml commit
-# Select: "feat: feat/add-flux-secrets"
-
-# Bug fix with custom message
-git checkout -b fix/yaml-output
-# ... make changes ...
-task --taskfile taskfiles/git.yaml commit
-# Select: "CUSTOM MESSAGE"
-# Enter: "fix(kcl): correct YAML formatting in flux module"
+# Select the files to stage →
+#   type: fix → ticket: CLOUD-42 → summary: "Correct YAML formatting in flux module"
+# Produces: "fix: CLOUD-42: Correct YAML formatting in flux module"
 ```
 
 </details>

--- a/taskfiles/README.md
+++ b/taskfiles/README.md
@@ -893,29 +893,71 @@ task --taskfile taskfiles/git.yaml pr
 
 </details>
 
-<details><summary><b>🌿 branch - Create New Branch from Main</b></summary>
+<details><summary><b>🌿 branch - Create a convention-compliant branch from main</b></summary>
 
-Create and push a new branch from main with proper tracking.
+Create and push a new branch from main whose name follows the Git Development/Review Flow
+naming convention: `<type>/[<ticket>_]<snake_case_description>`, all lowercase.
 
 ```bash
 task --taskfile taskfiles/git.yaml branch
 ```
 
 **Workflow:**
-1. Switches to main
-2. Shows current branches
-3. Pulls latest from main
-4. Prompts for new branch name
-5. Creates local branch
-6. Pushes to remote
-7. Sets upstream tracking to origin/main
+1. Switches to main and rebases onto latest
+2. **Type:** `gum choose` — `feature` / `hotfix` / `bugfix` / `chore`
+3. **Ticket:** lowercase `project-number` (e.g. `cloud-42`) — **mandatory for `feature`/`hotfix`**, optional otherwise; validated against `^[a-z]+-[0-9]+$`
+4. **Description:** free text, auto-normalized to lowercase `snake_case`
+5. **Confirm:** review the assembled name, then create + push with upstream tracking
 
 **Example:**
 ```bash
 task --taskfile taskfiles/git.yaml branch
-# Enter: "feat/add-dagger-docs"
-# Creates and pushes feat/add-dagger-docs
+# type: feature → ticket: cloud-42 → description: "add email to userinfo json"
+# Creates and pushes: feature/cloud-42_add_email_to_userinfo_json
 ```
+
+</details>
+
+<details><summary><b>🏷️ tag - Create a SemVer tag</b></summary>
+
+Tag the repository with a Semantic Versioning tag, bumped from the latest existing tag.
+
+```bash
+task --taskfile taskfiles/git.yaml tag
+```
+
+**Workflow:**
+1. Runs the `commit` task first
+2. Reads the latest tag (`git describe --tags`), preserving any `v` prefix
+3. **Bump:** `gum choose` — `patch` / `minor` / `major` (next version previewed) or `custom`
+4. `custom` is validated against SemVer (`v1.2.3` / `1.2.3`)
+5. **Confirm**, then `git tag -a` and push the tag
+
+**Example:**
+```bash
+task --taskfile taskfiles/git.yaml tag
+# latest: v1.2.9 → select "minor" → creates and pushes v1.3.0
+```
+
+</details>
+
+<details><summary><b>📌 issue - Create an issue (GitHub or GitLab)</b></summary>
+
+Create an issue on the detected forge. GitHub uses the `repository-linting` dagger blueprint
+(AI-assisted issue content); GitLab uses `glab issue create`.
+
+```bash
+task --taskfile taskfiles/git.yaml issue
+```
+
+**Workflow:**
+1. Detects the forge from `git remote get-url origin` (`github` / `gitlab`), or asks if ambiguous
+2. **GitHub:** prompts for repository, content and AI model → `dagger call … create-issue`
+3. **GitLab:** prompts for title and description → `glab issue create`
+
+**Requirements:**
+- GitHub path: `GITHUB_TOKEN` env var + `dagger`
+- GitLab path: `glab` installed and authenticated
 
 </details>
 

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -94,11 +94,11 @@ tasks:
         TYPE=$(gum choose --header "Conventional Commits type (select 'none' to omit):" \
           none feat fix docs refactor test chore build ci perf "feat!")
 
-        # Ticket reference: UPPERCASE, PROJECT-NUMBER, validated in a loop
-        TICKET=$(gum input --header "Ticket reference (UPPERCASE, e.g. CLOUD-42):" \
-          --value "{{ .TICKET }}" --placeholder "PROJECT-123" | tr '[:lower:]' '[:upper:]')
-        while ! echo "$TICKET" | grep -qE '^[A-Z]+-[0-9]+$'; do
-          TICKET=$(gum input --header "Invalid — must be PROJECT-NUMBER (e.g. CLOUD-42):" \
+        # Ticket reference: optional. If given it must be UPPERCASE PROJECT-NUMBER (validated in a loop).
+        TICKET=$(gum input --header "Ticket reference (e.g. CLOUD-42; leave empty for none):" \
+          --value "{{ .TICKET }}" --placeholder "PROJECT-123 (optional)" | tr '[:lower:]' '[:upper:]')
+        while [[ -n "$TICKET" ]] && ! echo "$TICKET" | grep -qE '^[A-Z]+-[0-9]+$'; do
+          TICKET=$(gum input --header "Invalid — PROJECT-NUMBER (e.g. CLOUD-42), or leave empty:" \
             --value "$TICKET" | tr '[:lower:]' '[:upper:]')
         done
 
@@ -110,11 +110,11 @@ tasks:
             gum style --foreground 214 "Summary is required."
             continue
           fi
-          if [[ "$TYPE" == "none" ]]; then
-            SUBJECT="${TICKET}: ${SUMMARY}"
-          else
-            SUBJECT="${TYPE}: ${TICKET}: ${SUMMARY}"
-          fi
+          # Assemble [<type>: ][<TICKET>: ]<Summary> — each prefix part is optional
+          PREFIX=""
+          [[ "$TYPE" != "none" ]] && PREFIX="${TYPE}: "
+          [[ -n "$TICKET" ]] && PREFIX="${PREFIX}${TICKET}: "
+          SUBJECT="${PREFIX}${SUMMARY}"
           FIRST_CHAR="${SUMMARY:0:1}"
           if [[ "$FIRST_CHAR" != "$(echo "$FIRST_CHAR" | tr '[:lower:]' '[:upper:]')" ]]; then
             gum style --foreground 214 "Summary must start with a capital letter."
@@ -155,14 +155,55 @@ tasks:
         git push -u origin "$CURRENT_BRANCH"
 
   pr:
-    desc: Create pull request into main
+    desc: Create a pull/merge request into main (GitHub via gh, GitLab via glab)
     cmds:
       - task: commit
-      - gh pr create -t "{{ .BRANCH }}" -b "{{ .BRANCH }} branch into main"
-      - sleep 2s
-      # - gh pr checks $(gh pr list | grep "^[^#;]" | awk '{print $1}') --watch
-      - gh pr merge $(gh pr list | grep "^[^#;]" | grep '{{ .BRANCH }}' | awk '{print $1}') --auto --rebase --delete-branch
-      - git checkout main && git pull
+      - |
+        set -euo pipefail
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # Detect the forge from the origin remote; fall back to an interactive choice
+        REMOTE_URL=$(git remote get-url origin)
+        case "$REMOTE_URL" in
+          *github.com*) PLATFORM=github ;;
+          *gitlab*)     PLATFORM=gitlab ;;
+          *)            PLATFORM=$(gum choose --header "Git platform?" github gitlab) ;;
+        esac
+
+        gum style --border double --padding "1 2" --border-foreground 212 \
+          "🔀 git:pr — ${BRANCH} → main (${PLATFORM})"
+
+        TITLE=$(gum input --header "PR/MR title:" --value "$BRANCH")
+        BODY=$(gum write --header "Description (ctrl+d to finish, esc to skip):" --width 72 --height 8)
+
+        # Draft = private/WIP per the review flow; a non-draft request is public and auto-merges (squash)
+        DRAFT=""
+        if gum confirm "Create as Draft (private / WIP — no auto-merge)?"; then
+          DRAFT=1
+        fi
+
+        case "$PLATFORM" in
+          github)
+            gh pr create --base main --head "$BRANCH" \
+              --title "$TITLE" --body "$BODY" ${DRAFT:+--draft}
+            if [[ -z "$DRAFT" ]]; then
+              gh pr merge --auto --squash --delete-branch
+            fi
+            ;;
+          gitlab)
+            glab mr create --target-branch main --source-branch "$BRANCH" \
+              --title "$TITLE" --description "$BODY" --remove-source-branch --squash-before-merge \
+              ${DRAFT:+--draft} --yes
+            if [[ -z "$DRAFT" ]]; then
+              glab mr merge --squash --remove-source-branch --when-pipeline-succeeds --yes
+            fi
+            ;;
+        esac
+
+        # Only return to main when the request was actually queued for merge (non-draft)
+        if [[ -z "$DRAFT" ]]; then
+          git checkout main && git pull --rebase
+        fi
 
   issue:
     desc: Create github issue

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -206,29 +206,89 @@ tasks:
         fi
 
   issue:
-    desc: Create github issue
+    desc: Create an issue (GitHub via dagger AI blueprint, GitLab via glab)
     cmds:
       - |
-        dagger call -m github.com/stuttgart-things/blueprints/repository-linting@v1.21.0 \
-        create-issue \
-        --repository $(gum input --header="REPOSITORY" --value "stuttgart-things/") \
-        --token env:GITHUB_TOKEN \
-        --content "$(gum input --header="CONTENT" --value "add issue for: ")" \
-        --model=$(gum input --header="AI MODEL" --value "gemini-2.5-flash")
+        set -euo pipefail
+
+        # Detect the forge from the origin remote; fall back to an interactive choice
+        REMOTE_URL=$(git remote get-url origin)
+        case "$REMOTE_URL" in
+          *github.com*) PLATFORM=github ;;
+          *gitlab*)     PLATFORM=gitlab ;;
+          *)            PLATFORM=$(gum choose --header "Git platform?" github gitlab) ;;
+        esac
+
+        gum style --border double --padding "1 2" --border-foreground 212 \
+          "📌 git:issue — ${PLATFORM}"
+
+        case "$PLATFORM" in
+          github)
+            dagger call -m github.com/stuttgart-things/blueprints/repository-linting@v1.21.0 \
+              create-issue \
+              --repository "$(gum input --header="REPOSITORY" --value "stuttgart-things/")" \
+              --token env:GITHUB_TOKEN \
+              --content "$(gum input --header="CONTENT" --value "add issue for: ")" \
+              --model="$(gum input --header="AI MODEL" --value "gemini-2.5-flash")"
+            ;;
+          gitlab)
+            TITLE=$(gum input --header "Issue title:" --placeholder "Add email to userinfo json")
+            DESC=$(gum write --header "Description (ctrl+d to finish, esc to skip):" --width 72 --height 8)
+            glab issue create --title "$TITLE" --description "$DESC"
+            ;;
+        esac
 
   branch:
-    desc: Create branch from main
+    desc: Create a convention-compliant branch from main (type + ticket + snake_case)
     cmds:
       - git checkout main
-      - git branch
-      - git pull
+      - git pull --rebase
       - |
-        echo "Enter to be created (remote) branch:"
-        read BRANCH_NAME;
-        git checkout -b ${BRANCH_NAME}
-        git push origin ${BRANCH_NAME}
-      - git branch
-      - git branch --set-upstream-to=origin/main ${BRANCH_NAME}
+        set -euo pipefail
+
+        gum style --border double --padding "1 2" --border-foreground 212 \
+          "🌿 git:branch — new branch from main"
+
+        # 1) Branch type — every transient branch must start with its type + a slash
+        TYPE=$(gum choose --header "Branch type:" feature hotfix bugfix chore)
+
+        # 2) Ticket reference (lowercase project-number, e.g. cloud-42).
+        #    Mandatory for feature/hotfix, optional otherwise (per naming convention).
+        TICKET=$(gum input --header "Ticket reference (e.g. cloud-42; empty = none):" \
+          --placeholder "project-123" | tr '[:upper:]' '[:lower:]')
+        if [[ "$TYPE" == "feature" || "$TYPE" == "hotfix" ]]; then
+          while ! echo "$TICKET" | grep -qE '^[a-z]+-[0-9]+$'; do
+            TICKET=$(gum input --header "$TYPE requires a ticket — project-number (e.g. cloud-42):" \
+              --value "$TICKET" | tr '[:upper:]' '[:lower:]')
+          done
+        else
+          while [[ -n "$TICKET" ]] && ! echo "$TICKET" | grep -qE '^[a-z]+-[0-9]+$'; do
+            TICKET=$(gum input --header "Invalid — project-number (e.g. cloud-42), or leave empty:" \
+              --value "$TICKET" | tr '[:upper:]' '[:lower:]')
+          done
+        fi
+
+        # 3) Short description, normalized to lowercase snake_case
+        while :; do
+          DESC=$(gum input --header "Short description (will be snake_cased):" \
+            --placeholder "add email to userinfo json")
+          DESC=$(echo "$DESC" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//')
+          [[ -n "$DESC" ]] && break
+          gum style --foreground 214 "A description is required."
+        done
+
+        # 4) Assemble: <type>/[<ticket>_]<description>
+        if [[ -n "$TICKET" ]]; then
+          BRANCH_NAME="${TYPE}/${TICKET}_${DESC}"
+        else
+          BRANCH_NAME="${TYPE}/${DESC}"
+        fi
+
+        gum style --border normal --padding "0 1" --border-foreground 45 "$BRANCH_NAME"
+        gum confirm "Create and push this branch?" || { gum style --foreground 214 "Aborted."; exit 0; }
+
+        git checkout -b "$BRANCH_NAME"
+        git push -u origin "$BRANCH_NAME"
 
   run-pre-commit-hook:
     deps:
@@ -286,11 +346,42 @@ tasks:
         git checkout ${branch} && git pull
 
   tag:
-    desc: Tag repo
+    desc: Create a SemVer tag (bump patch/minor/major from the latest tag)
     cmds:
       - task: commit
       - |
-        echo "Enter to be created (remote) tag on the repository:"
-        read TAG_NAME;
-        git tag -a ${TAG_NAME} -m 'updated for ${TAG_NAME} on {{ .DATE }}'
-        git push origin --tags
+        set -euo pipefail
+
+        LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        gum style --border double --padding "1 2" --border-foreground 212 \
+          "🏷️  git:tag — latest: ${LATEST:-none}"
+
+        # Split the latest tag into (optional v-prefix) major.minor.patch
+        PREFIX=""; BASE="${LATEST}"
+        if [[ "$LATEST" == v* ]]; then PREFIX="v"; BASE="${LATEST#v}"; fi
+        IFS=. read -r MA MI PA <<< "${BASE:-0.0.0}"
+        MA=${MA:-0}; MI=${MI:-0}; PA=${PA:-0}
+
+        BUMP=$(gum choose --header "Version bump:" \
+          "patch (${PREFIX}${MA}.${MI}.$((PA+1)))" \
+          "minor (${PREFIX}${MA}.$((MI+1)).0)" \
+          "major (${PREFIX}$((MA+1)).0.0)" \
+          "custom")
+
+        case "$BUMP" in
+          patch*) NEXT="${PREFIX}${MA}.${MI}.$((PA+1))" ;;
+          minor*) NEXT="${PREFIX}${MA}.$((MI+1)).0" ;;
+          major*) NEXT="${PREFIX}$((MA+1)).0.0" ;;
+          custom)
+            NEXT=$(gum input --header "Tag (SemVer, e.g. v1.2.3):" --value "${LATEST}")
+            while ! echo "$NEXT" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+$'; do
+              NEXT=$(gum input --header "Invalid — must be SemVer (v1.2.3 / 1.2.3):" --value "$NEXT")
+            done
+            ;;
+        esac
+
+        gum style --border normal --padding "0 1" --border-foreground 45 "$NEXT"
+        gum confirm "Create and push tag ${NEXT}?" || { gum style --foreground 214 "Aborted."; exit 0; }
+
+        git tag -a "$NEXT" -m "Release ${NEXT} on {{ .DATE }}"
+        git push origin "$NEXT"

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -150,9 +150,9 @@ tasks:
 
         # 7) Sync with remote (rebase to keep history linear per ff-only policy) & push
         if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-          git pull --rebase --autostash
+          gum spin --title "Rebasing onto upstream…" --show-error -- git pull --rebase --autostash
         fi
-        git push -u origin "$CURRENT_BRANCH"
+        gum spin --title "Pushing to origin…" --show-error -- git push -u origin "$CURRENT_BRANCH"
 
   pr:
     desc: Create a pull/merge request into main (GitHub via gh, GitLab via glab)
@@ -202,7 +202,8 @@ tasks:
 
         # Only return to main when the request was actually queued for merge (non-draft)
         if [[ -z "$DRAFT" ]]; then
-          git checkout main && git pull --rebase
+          git checkout main
+          gum spin --title "Pulling main…" --show-error -- git pull --rebase
         fi
 
   issue:
@@ -242,7 +243,7 @@ tasks:
     desc: Create a convention-compliant branch from main (type + ticket + snake_case)
     cmds:
       - git checkout main
-      - git pull --rebase
+      - gum spin --title "Pulling main…" --show-error -- git pull --rebase
       - |
         set -euo pipefail
 
@@ -288,7 +289,7 @@ tasks:
         gum confirm "Create and push this branch?" || { gum style --foreground 214 "Aborted."; exit 0; }
 
         git checkout -b "$BRANCH_NAME"
-        git push -u origin "$BRANCH_NAME"
+        gum spin --title "Pushing new branch…" --show-error -- git push -u origin "$BRANCH_NAME"
 
   run-pre-commit-hook:
     deps:
@@ -331,7 +332,7 @@ tasks:
     desc: Switch to remote branch
     cmds:
       - |
-        git fetch
+        gum spin --title "Fetching…" --show-error -- git fetch
         branches=($(git branch -r | grep -v 'origin/HEAD' | sed 's|origin/||'))
         branch=$(printf "%s\n" "${branches[@]}" | gum choose)
         git switch -c ${branch} --track origin/${branch}
@@ -343,7 +344,8 @@ tasks:
       - |
         branches=$(git branch -a | grep -v 'remotes')
         branch=$(printf "%s\n" "${branches[@]}" | gum choose)
-        git checkout ${branch} && git pull
+        git checkout ${branch}
+        gum spin --title "Pulling…" --show-error -- git pull
 
   tag:
     desc: Create a SemVer tag (bump patch/minor/major from the latest tag)
@@ -384,4 +386,4 @@ tasks:
         gum confirm "Create and push tag ${NEXT}?" || { gum style --foreground 214 "Aborted."; exit 0; }
 
         git tag -a "$NEXT" -m "Release ${NEXT} on {{ .DATE }}"
-        git push origin "$NEXT"
+        gum spin --title "Pushing tag ${NEXT}…" --show-error -- git push origin "$NEXT"

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -44,33 +44,115 @@ tasks:
         cat {{ .EXPORT_PATH }}
 
   commit:
-    desc: Commit + push code into branch
+    desc: Interactively stage selected files & commit with a convention-compliant message
     deps:
       - check
+    vars:
+      # Parse a ticket reference (e.g. feature/cloud-42_... -> CLOUD-42) from the branch name
+      TICKET:
+        sh: git rev-parse --abbrev-ref HEAD | grep -oiE '[a-z]+-[0-9]+' | head -n1 | tr '[:lower:]' '[:upper:]' || true
     cmds:
-      - git branch --set-upstream-to=origin/{{ .BRANCH }}
-      - git pull
-      - git status
       - |
-        git add *
-        git status
-        if [[ -n $(git status --porcelain) ]]; then
-          echo "Review the changes above."
-          gum confirm "Do you want to commit these changes?" || exit 0
+        set -euo pipefail
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-          echo "ENTER COMMIT MESSAGE"
-          COMMIT_MESSAGE=$(gum choose "CUSTOM MESSAGE" "feat: {{ .BRANCH }}" "fix: {{ .BRANCH }}" "BREAKING CHANGE: {{ .BRANCH }}")
+        gum style --border double --padding "1 2" --border-foreground 212 \
+          "💾 git:commit — ${CURRENT_BRANCH}"
 
-          if [ "$COMMIT_MESSAGE" == "CUSTOM MESSAGE" ]; then
-            CHANGED_FILES=$(git status --short | awk '{print $2}' | tr '\n' ' ')
-            COMMIT_MESSAGE=$(gum input --placeholder "Commit message" --value "Changed: $CHANGED_FILES")
-          fi
-
-          git commit --allow-empty -a -m "$COMMIT_MESSAGE"
-        else
-          echo "No changes to commit."
+        # 1) Bail out early if there is nothing to commit
+        if [[ -z "$(git status --porcelain)" ]]; then
+          gum style --foreground 214 "No changes to commit."
+          exit 0
         fi
-      - git push origin -u {{ .BRANCH }}
+
+        # 2) Show the current status for review
+        echo "Current working tree:"
+        git -c color.status=always status --short
+
+        # 3) Interactively select which files should land in the commit (NOT all by default)
+        SELECTED=$(git -c core.quotepath=false status --porcelain \
+          | gum choose --no-limit --height 20 \
+              --header "Select files to stage (space=toggle, ctrl+a=all, enter=confirm):")
+
+        if [[ -z "$SELECTED" ]]; then
+          gum style --foreground 214 "No files selected — aborting."
+          exit 0
+        fi
+
+        # Stage only the selected files (strip the 2-char status + space prefix; handle renames)
+        while IFS= read -r line; do
+          [[ -z "$line" ]] && continue
+          path="${line:3}"
+          case "$path" in *" -> "*) path="${path##* -> }";; esac
+          git add -- "$path"
+        done <<< "$SELECTED"
+
+        echo "Staged for commit:"
+        git -c color.status=always status --short
+
+        # 4) Build a convention-compliant subject: [<type>: ]<TICKET-REF>: <Summary>
+        TYPE=$(gum choose --header "Conventional Commits type (select 'none' to omit):" \
+          none feat fix docs refactor test chore build ci perf "feat!")
+
+        # Ticket reference: UPPERCASE, PROJECT-NUMBER, validated in a loop
+        TICKET=$(gum input --header "Ticket reference (UPPERCASE, e.g. CLOUD-42):" \
+          --value "{{ .TICKET }}" --placeholder "PROJECT-123" | tr '[:lower:]' '[:upper:]')
+        while ! echo "$TICKET" | grep -qE '^[A-Z]+-[0-9]+$'; do
+          TICKET=$(gum input --header "Invalid — must be PROJECT-NUMBER (e.g. CLOUD-42):" \
+            --value "$TICKET" | tr '[:lower:]' '[:upper:]')
+        done
+
+        # Summary: must start with a capital letter; full subject line must be <= 72 chars
+        while :; do
+          SUMMARY=$(gum input --header "Summary (present-tense verb, Capitalized):" \
+            --placeholder "Add missing LICENSE to pyproject.toml")
+          if [[ -z "$SUMMARY" ]]; then
+            gum style --foreground 214 "Summary is required."
+            continue
+          fi
+          if [[ "$TYPE" == "none" ]]; then
+            SUBJECT="${TICKET}: ${SUMMARY}"
+          else
+            SUBJECT="${TYPE}: ${TICKET}: ${SUMMARY}"
+          fi
+          FIRST_CHAR="${SUMMARY:0:1}"
+          if [[ "$FIRST_CHAR" != "$(echo "$FIRST_CHAR" | tr '[:lower:]' '[:upper:]')" ]]; then
+            gum style --foreground 214 "Summary must start with a capital letter."
+            continue
+          fi
+          if (( ${#SUBJECT} > 72 )); then
+            gum style --foreground 214 "Subject too long (${#SUBJECT}/72) — please shorten."
+            continue
+          fi
+          break
+        done
+
+        # 5) Optional extended body (separated from the subject by a blank line)
+        if gum confirm "Add an extended description (body)?"; then
+          BODY=$(gum write --header "Body (ctrl+d to finish, esc to skip):" --width 72 --height 10)
+        else
+          BODY=""
+        fi
+
+        if [[ -n "$BODY" ]]; then
+          MESSAGE=$(printf '%s\n\n%s\n' "$SUBJECT" "$BODY")
+        else
+          MESSAGE="$SUBJECT"
+        fi
+
+        # 6) Review the final message and confirm
+        gum style --border normal --padding "1 2" --border-foreground 45 "$MESSAGE"
+        if ! gum confirm "Commit with this message?"; then
+          gum style --foreground 214 "Aborted (staged files kept)."
+          exit 0
+        fi
+        git commit -m "$MESSAGE"
+
+        # 7) Sync with remote (rebase to keep history linear per ff-only policy) & push
+        if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+          git pull --rebase --autostash
+        fi
+        git push -u origin "$CURRENT_BRANCH"
 
   pr:
     desc: Create pull request into main


### PR DESCRIPTION
## Summary
Significantly improved the `commit` and `pr` Git workflow tasks to enforce better commit hygiene and support multi-platform (GitHub/GitLab) pull/merge request creation. The `commit` task now uses interactive per-file staging and validates convention-compliant commit messages, while the `pr` task auto-detects the Git forge and supports both draft and auto-merge workflows.

## Key Changes

### `commit` Task
- **Interactive per-file staging:** Replaced blanket `git add *` with `gum choose --no-limit` to let users select exactly which files to commit
- **Convention-compliant subject line:** Enforces `[<type>: ][<TICKET-REF>: ]<Summary>` format with validation:
  - Type: Conventional Commits type (feat, fix, docs, etc.) or omitted
  - Ticket reference: Auto-parsed from branch name (e.g., `feature/cloud-42_…` → `CLOUD-42`), validated as `PROJECT-NUMBER`, forced UPPERCASE
  - Summary: Must start with capital letter; subject capped at 72 characters
- **Optional extended body:** Multi-line description via `gum write`, blank-line separated from subject
- **Rebase-based sync:** Uses `git pull --rebase --autostash` (if upstream exists) instead of simple pull, keeping history linear
- **Early exit:** Aborts immediately if working tree is clean
- **Better UX:** Styled headers, colored status output, confirmation before commit

### `pr` Task
- **Platform auto-detection:** Reads `git remote get-url origin` to detect GitHub vs. GitLab; falls back to interactive choice if ambiguous
- **Draft support:** `gum confirm` to create as Draft (private/WIP) — skips auto-merge for draft requests
- **Squash merge strategy:** Both platforms configured to squash commits on merge (per "ENFORCE Squash" policy)
- **Unified workflow:** Same task works on both GitHub (via `gh`) and GitLab (via `glab`)
- **Conditional main checkout:** Only switches back to main when the request was queued for merge (non-draft)
- **User-provided title & description:** Prompted via `gum input` / `gum write` instead of auto-generated from branch name

### Documentation
- Updated README with detailed feature descriptions, workflow steps, and examples for both tasks
- Clarified the convention-compliant message format and multi-platform support

https://claude.ai/code/session_01MEpGbXpg7gdAPH6xp2kCMJ